### PR TITLE
Add ability to train on smaller cards like the 24GB 3090 or 4090. Fixed epoch argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ python chat.py
 ```
 python train_mamba.py --model state-spaces/mamba-2.8b --tokenizer EleutherAI/gpt-neox-20b --learning_rate 5e-5 --batch_size 4 --data_path ./data/ultrachat_small.jsonl --num_epochs 3
 ```
+
+<br>
+
+**If you have a 24GB card (3090, 4090, etc.) you can use these settings:**
+```
+**Fine-Tune Mamba (the base model) on a subset of the Ultrachat dataset:**
+```
+python train_mamba.py --model /srv/models/mamba-2.8b --tokenizer EleutherAI/gpt-neox-20b --learning_rate 5e-5 --batch_size 1 --gradient_accumulation_steps 4 --optim paged_adamw_8bit --data_path ./data/ultrachat_small.jsonl --num_epochs 3
+```
+

--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ python train_mamba.py --model state-spaces/mamba-2.8b --tokenizer EleutherAI/gpt
 
 **If you have a 24GB card (3090, 4090, etc.) you can use these settings:**
 ```
-python train_mamba.py --model /srv/models/mamba-2.8b --tokenizer EleutherAI/gpt-neox-20b --learning_rate 5e-5 --batch_size 1 --gradient_accumulation_steps 4 --optim paged_adamw_8bit --data_path ./data/ultrachat_small.jsonl --num_epochs 3
+python train_mamba.py --model state-spaces/mamba-2.8b --tokenizer EleutherAI/gpt-neox-20b --learning_rate 5e-5 --batch_size 1 --gradient_accumulation_steps 4 --optim paged_adamw_8bit --data_path ./data/ultrachat_small.jsonl --num_epochs 3
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ python train_mamba.py --model state-spaces/mamba-2.8b --tokenizer EleutherAI/gpt
 
 **If you have a 24GB card (3090, 4090, etc.) you can use these settings:**
 ```
-**Fine-Tune Mamba (the base model) on a subset of the Ultrachat dataset:**
-```
 python train_mamba.py --model /srv/models/mamba-2.8b --tokenizer EleutherAI/gpt-neox-20b --learning_rate 5e-5 --batch_size 1 --gradient_accumulation_steps 4 --optim paged_adamw_8bit --data_path ./data/ultrachat_small.jsonl --num_epochs 3
 ```
 

--- a/train_mamba.py
+++ b/train_mamba.py
@@ -33,6 +33,8 @@ def run(args):
             learning_rate=args.learning_rate,
             num_train_epochs=args.num_epochs,
             per_device_train_batch_size=args.batch_size,
+            gradient_accumulation_steps=args.gradient_accumulation_steps,
+            optim=args.optim,
             output_dir="mamba-chat",
             logging_steps=50,
             save_steps=500,
@@ -49,6 +51,8 @@ if __name__ == "__main__":
     parser.add_argument("--tokenizer", type=str, default="EleutherAI/gpt-neox-20b")
     parser.add_argument("--learning_rate", type=float, default=5e-5)
     parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--gradient_accumulation_steps", type=int, default=1)
+    parser.add_argument("--optim", type=str, default="adamw_torch")
     parser.add_argument("--data_path", type=str, default="./data/ultrachat_small.jsonl")
     parser.add_argument("--num_epochs", type=int, default=1)
     args = parser.parse_args()

--- a/train_mamba.py
+++ b/train_mamba.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     parser.add_argument("--learning_rate", type=float, default=5e-5)
     parser.add_argument("--batch_size", type=int, default=4)
     parser.add_argument("--data_path", type=str, default="./data/ultrachat_small.jsonl")
-    parser.add_argument("--num_epochs", type=str, default=1)
+    parser.add_argument("--num_epochs", type=int, default=1)
     args = parser.parse_args()
 
     run(args)


### PR DESCRIPTION
I have added the ability to train on a smaller card like the 4090. I added instructions to the README file.

Also, the trainer failed to execute due to the epoch argument being cast as a string. I updated it to be an int and everything works now. Here's the original error:
```
Traceback (most recent call last):
  File "/home/jupyter-rwl4/mamba-chat/train_mamba.py", line 56, in <module>
    run(args)
  File "/home/jupyter-rwl4/mamba-chat/train_mamba.py", line 43, in run
    trainer.train()
  File "/home/jupyter-rwl4/.local/lib/python3.10/site-packages/transformers/trainer.py", line 1555, in train
    return inner_training_loop(
  File "/home/jupyter-rwl4/.local/lib/python3.10/site-packages/transformers/trainer.py", line 1597, in _inner_training_loop
    max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
TypeError: must be real number, not str
```