### PR TITLE
🐞 fix: triton requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ mamba-ssm==1.0.1
 accelerate==0.25.0
 bitsandbytes==0.41.3
 scipy==1.11.4
+triton==2.0.0


### PR DESCRIPTION
I found that the default installation of `triton==2.1.0` when creating the environment is incompatible with your code. It seems necessary to adjust it to `triton==2.0.0` for your code to function properly.






