### PR TITLE
enhancement: better model_save

### DIFF
--- a/train_mamba.py
+++ b/train_mamba.py
@@ -35,7 +35,7 @@ def run(args):
             per_device_train_batch_size=args.batch_size,
             gradient_accumulation_steps=args.gradient_accumulation_steps,
             optim=args.optim,
-            output_dir="mamba-chat",
+            output_dir=args.output_dir,
             logging_steps=50,
             save_steps=500,
         ),
@@ -44,6 +44,7 @@ def run(args):
 
     trainer.train()
 
+    trainer.save_model(output_dir=f"{args.output_dir}/complete")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -55,6 +56,7 @@ if __name__ == "__main__":
     parser.add_argument("--optim", type=str, default="adamw_torch")
     parser.add_argument("--data_path", type=str, default="./data/ultrachat_small.jsonl")
     parser.add_argument("--num_epochs", type=int, default=1)
+    parser.add_argument("--output_dir", type=str, default="mamba-chat")
     args = parser.parse_args()
 
     run(args)

--- a/trainer/mamba_trainer.py
+++ b/trainer/mamba_trainer.py
@@ -17,7 +17,7 @@ class MambaTrainer(Trainer):
 
         return lm_loss
 
-    def save_model(self, output_dir, _internal_call):
+    def save_model(self, output_dir, _internal_call: bool = False):
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
             


### PR DESCRIPTION
This pull request has 3 small changes to make saving the model easier:

1) sets a default value for `_internal_call` in `save_model` like in hf trainer <https://github.com/huggingface/transformers/blob/c48787f347bd604f656c2cfff730e029c8f8c1fe/src/transformers/trainer.py#L2797C12-L2797C12>
2) add arg parser for `output_dir`
3) calls save_model when training is complete